### PR TITLE
fix: Support GitHub npm install by adding 'prepare' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "prettier src/**/*.ts --write && git status",
     "build": "rimraf dist && npm run build:lib && npm test",
     "build:lib": "tsc -p tsconfig.json",
+    "prepare": "npm run build",
     "prepublish:npm": "npm run build",
     "publish:npm": "npm publish --access public",
     "prepublish:next": "npm run build",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe:
Adds a 'prepare' script in package.json to properly support installing this package directly from GitHub
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when installing this package from GitHub directly, e.g. by running

```shell
$ npm install https://github.com/manekinekko/azure-database
```
the installed folder does not contain a `dist` folder nor a `lib` folder (as the latter is ignored), so the package effectively only contains metadata and doesn't work.

## What is the new behavior?

A `prepare` script has been added to `package.json` that's ran by `npm install` upon installing the package from GitHub which properly builds the sources.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[X] Maybe
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

I'm not sure if this affects regular publishes to npm, as I am not that familiar with maintaining packages, so you might want to check that out before merging this. I have confirmed that this script works by installing from my own branch:

```shell
$ npm install https://github.com/DenzoNL/azure-database#5fa5281469fc723d045c193f1394c2f047bd3a4f
```